### PR TITLE
(MVP-4035) Mathematical evaluation of uncertainty quantification

### DIFF
--- a/notebooks/model_evaluation/classification-tabnet-ensembl.ipynb
+++ b/notebooks/model_evaluation/classification-tabnet-ensembl.ipynb
@@ -13,13 +13,13 @@
      "output_type": "stream",
      "text": [
       "Obtaining file:///dss/dsshome1/04/di93zer/git/cellnet\n",
-      "  Preparing metadata (setup.py) ... \u001b[?25ldone\n",
-      "\u001b[?25hInstalling collected packages: cellnet\n",
+      "  Preparing metadata (setup.py) ... \u001B[?25ldone\n",
+      "\u001B[?25hInstalling collected packages: cellnet\n",
       "  Running setup.py develop for cellnet\n",
       "Successfully installed cellnet\n",
       "\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.1.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m23.1.2\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpython3 -m pip install --upgrade pip\u001b[0m\n"
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m A new release of pip is available: \u001B[0m\u001B[31;49m23.1.1\u001B[0m\u001B[39;49m -> \u001B[0m\u001B[32;49m23.1.2\u001B[0m\n",
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m To update, run: \u001B[0m\u001B[32;49mpython3 -m pip install --upgrade pip\u001B[0m\n"
      ]
     }
    ],
@@ -423,14 +423,24 @@
    "metadata": {},
    "source": [
     "**Data divisions:**\n",
-    "* In-distribution (`right` prediction): Test data (unseen donors) subsetted to `right` predictions. Consists only of known cell types.\n",
-    "* In-distribution (`wrong` predictions): Test data (unseen donors) subsetted to `wrong` predictions. Consists only of known cell types.\n",
-    "* Out-of-distribution (OOD): Consists of unkown cell types (not seen during training)\n",
+    "\n",
+    "* In-distribution (`right` predictions)\n",
+    "    * Test data (unseen donors) subset to `right` predictions\n",
+    "    * Consists only of known cell types\n",
+    "* In-distribution (`wrong` predictions)\n",
+    "    * Test data (unseen donors) subset to `wrong` predictions\n",
+    "    * Consists only of known cell types.\n",
+    "* Out-of-distribution (OOD)\n",
+    "    * Consists of cells which are not included in the training, validation or test data\n",
+    "    * Consists of unknown cell types (not seen during training)\n",
+    "    * It's impossible for the network to predict those cell types exactly as it is not trained on those labels\n",
+    "    * This is supposed to simulate new unknown cell types (cell types that don't fully fit any of the cell types the model was trained on)\n",
+    "    * &rarr; The model should have a higher uncertainty on those cell types\n",
     "\n",
     "**Model details:**\n",
-    "* Uncertainty is calculated based on max predicted probablility: `uncertainty = 1. - predicted_probablilty.max(axis=1)`\n",
-    "* Predicted probablitlies are calculated by averaging the probabilities of the individual ensemble models\n",
-    "* Ensemble consists of TabNet models which are trained with different random intializations (see https://arxiv.org/abs/1612.01474)\n",
+    "* Uncertainty is calculated based on max predicted probability: `uncertainty = 1. - predicted_probablilty.max(axis=1)`\n",
+    "* Predicted probabilities are calculated by averaging the probabilities of the individual ensemble models\n",
+    "* Ensemble consists of TabNet models which are trained with different random initialization (see https://arxiv.org/abs/1612.01474)\n",
     "\n",
     "**Runtime considerations:**\n",
     "* Training and inference time increases linearly with the number of models in the ensemble (twice the number of models &rarr; twice the time)\n",
@@ -620,7 +630,7 @@
    "source": [
     "Visualize distribution shift between\n",
     "1. in-distribution right predictions (blue) vs in-distribution wrong predictions (orange) &rarr; wrong predictions should have higher uncertainty\n",
-    "2. in-distribtuion right predictions (blue) vs out-of-distribution (green) &rarr; unknown cell types should have higher uncertainty\n"
+    "2. in-distribution right predictions (blue) vs out-of-distribution (green) &rarr; unknown cell types should have higher uncertainty\n"
    ]
   },
   {
@@ -694,7 +704,7 @@
     "\n",
     "Two evaluation cases:\n",
     "1. Right vs wrong predictions (in-distribution)\n",
-    "2. Known (in-distribution) vs unkown (out-of-distribution) cell types\n",
+    "2. Known (in-distribution) vs unknown (out-of-distribution) cell types\n",
     "\n",
     "ROC curve: https://en.wikipedia.org/wiki/Receiver_operating_characteristic"
    ]


### PR DESCRIPTION
Hi @rm1113 & @siberianisaev & @evanbiederstedt, 

I added the evaluation of the uncertainty quantification under `notebooks/model_evaluation/classification-tabnet-ensembl.ipynb`

# Description

This PR adds additional evaluation metrics for the uncertainty estimates beyond just overlaying the uncertainty estimates over the TSNE plots. 

**Data splits over which to evaluate uncertainty metrics:**
- In-distribution data subsetted to right predictions (only known cell types)
- In-distribution data subsetted to wrong predictions (only known cell types)
- Out-of-distribution (unknown cell types)

Splits to compare: 
1. right vs wrong predictions
2. out-of-distribution vs right predictions

**Evaluation:**
- Separation of uncertainty estimates between right predictions and wrong predictions (wrong predictions should have higher uncertainty scores)
- Separation of in-distribution and out-of-distribution data (unknown cell types should have higher uncertainty scores)

**Metrics:** 
- Plot distribution of uncertainty scores
- Look at ROC curves to judge how well different data splits can be divided based on uncertainty estimates. The goal is predict from which split a sample comes from based on the uncertainty score.

# Screenshots

**Distribution of uncertainty estimates:** 

![uncertainty_distribution](https://github.com/kharchenkolab/cellnet/assets/47145207/3affc4aa-c29a-446e-99e9-ac3ddf49e2cb)

**Change of ROC curve with number of ensembles:**
Based on this we can judge how many models to use in the ensemble. I think using 4-5 models seems like a good choice. 

![roc_curve](https://github.com/kharchenkolab/cellnet/assets/47145207/8ba9f328-f040-4b28-a079-959d00692e32)






